### PR TITLE
Add support for building on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "py-randomprime"
 version = "0.1.0"
 edition = "2018"
 
+[build-dependencies]
+pyo3-build-config = "0.17.1"
+
 [dependencies]
 memmap = "0.7"
 randomprime = { path = "randomprime" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+  pyo3_build_config::add_extension_module_link_args();
+}
+


### PR DESCRIPTION
Based on https://pyo3.rs/v0.14.4/building_and_distribution.html#macos:

> On macOS, because the extension-module feature disables linking to libpython ([see the next section](https://pyo3.rs/v0.14.4/building_and_distribution.html#the-extension-module-feature)), some additional linker arguments need to be set.

This just adds the `pyo3-build-config` build dependency and a `build.rs` file which sets the correct linker args based on target platform.

I'm using version 0.17.1 for the dependency (the latest version); not sure if you want to bring that version number in line with the rest of `pyo3`, but it seems to not matter for this project.