### PR TITLE
Multiple build updates:

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,12 +1,16 @@
 name: Python Package
 
 on:
-  pull_request:
   push:
     branches:
-      - '*'
+     - main
     tags:
       - '*'
+
+  merge_group:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -27,33 +31,19 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.7"
-            
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: powerpc-unknown-linux-gnu
-          override: true
-     
+      - name: Add powerpc-unknown-linux-gnu
+        run: rustup target add --toolchain stable powerpc-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
       
-      - name: Install Python packages
-        run: python -m pip install --upgrade build cibuildwheel==2.2.0a1
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir dist
+        run: pipx run cibuildwheel==2.14.1 --output-dir dist
         env:
-          CIBW_BUILD_FRONTEND: build
-          CIBW_BUILD: 'cp37-*'
-          CIBW_SKIP: '*-win32'
+          CIBW_BUILD: 'cp38-*'
+          CIBW_SKIP: '*-win32 *-manylinux_i686'
 
       - name: build sdist
-        run: python -m build --sdist
-        if: ${{ matrix.os == 'macos-12' }}
+        run: pipx run build --sdist
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Check if there are changes
         run: git diff --exit-code
@@ -81,9 +71,12 @@ jobs:
       - name: Avoid issues with Git's solution for CVE-2022-24765 breaking setuptools-scm
         run: git config --global --add safe.directory $(pwd)
 
-      - run: rustup target add --toolchain stable powerpc-unknown-linux-gnu
+      - name: Add powerpc-unknown-linux-gnu
+        run: rustup target add --toolchain stable powerpc-unknown-linux-gnu
+
       - uses: Swatinem/rust-cache@v2
-      - run: /opt/python/cp37-cp37m/bin/python -m venv .venv
+
+      - run: /opt/python/cp38-cp38/bin/python -m venv .venv
      
       - name: Update pip
         run: .venv/bin/python -m pip install --upgrade pip
@@ -123,11 +116,11 @@ jobs:
           - {name: 'Windows', image: 'windows-latest', wheel: 'win_amd64'}
           - {name: 'Linux', image: 'ubuntu-latest', wheel: 'manylinux_2_17_x86_64.manylinux2014_x86_64'}
         python:
-
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12.0-beta - 3.12.0'
 
     steps:
       - name: Checkout
@@ -172,7 +165,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.testpypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
       
       - name: Publish 📦 to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # py-randomprime
-Python 3.6+ bindings for aprilwade's randomprime.
+Python 3.8+ bindings for aprilwade's randomprime.
 Currently using toasterparty's fork.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ build-backend = "setuptools.build_meta"
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 write_to = "py_randomprime/version.py"
+
+[tool.cibuildwheel]
+build-frontend = "build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,10 +8,11 @@ classifiers =
     License :: OSI Approved :: MIT License
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Rust
 
 [options]
@@ -21,7 +22,7 @@ install_requires =
 include_package_data = True
 zip_safe = False
 
-python_requires = >=3.7
+python_requires = >=3.8
 
 [bdist_wheel]
-py_limited_api = cp37
+py_limited_api = cp38


### PR DESCRIPTION
- Use cibuildwheel recommended CI workflow
- Remove usage of abandoned rust GH actions
- Drop Python 3.7 (EOL, does not support universal2 wheels for macOS)